### PR TITLE
meta-rauc-raspberrypi: depends on lts-u-boot-mixins

### DIFF
--- a/meta-rauc-raspberrypi/conf/layer.conf
+++ b/meta-rauc-raspberrypi/conf/layer.conf
@@ -9,8 +9,5 @@ BBFILE_COLLECTIONS += "meta-rauc-raspberrypi"
 BBFILE_PATTERN_meta-rauc-raspberrypi = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-rauc-raspberrypi = "6"
 
-LAYERDEPENDS_meta-rauc-raspberrypi = "core rauc raspberrypi"
-# For u-boot support for raspberrypi5
-# https://git.yoctoproject.org/meta-lts-mixins scarthgap/u-boot branch
-LAYERRECOMMENDS_meta-rauc-raspberrypi = "lts-u-boot-mixin"
+LAYERDEPENDS_meta-rauc-raspberrypi = "core rauc raspberrypi lts-u-boot-mixin"
 LAYERSERIES_COMPAT_meta-rauc-raspberrypi = "nanbield scarthgap"


### PR DESCRIPTION
Scarthgap supports officially u-boot 2024.01[1]; raspberrypi5 is supported since u-boot 2024.04.

The commit b0f41f8634b3df6c91c2d7630a25a2a3cd401e42 recommends the layer meta-lts-mixins (scarthgap/u-boot) to support for raspberrypi5; that branch bumps u-boot to 2024.04[2] (lts-u-boot-mixins is a single recipe layer). The commit 2bef421abbcba71db0201bcf5c4b5c8c7bd41b92 reflects that requirement in the README. The layer keeps bumping the version of u-boot (2024.07[3], 2025.01[4], and 2025.04[5]).

The layer meta-rauc-raspberrypi patches the file rpi_arm64_defconfig; that file has changed since 2025.01[6][7], and the patch has been updated since commit 3414ec68088044014dc635ecc90cfc460b148c96.

Consequently, it causes the patch to fail if the layer lts-u-boot-mixins is **NOT** added. See the log attached below.

This changes the layer relationship from RECOMMENDS to DEPENDS to cause bibake to produce the error below if the layer lts-u-boot-mixins is missing:

	ERROR: Layer 'meta-rauc-raspberrypi' depends on layer 'lts-u-boot-mixin', but this layer is not enabled in your configuration

Fixes:

	patching file configs/rpi_arm64_defconfig
	Hunk #1 FAILED at 64.
	1 out of 1 hunk FAILED -- rejects in file configs/rpi_arm64_defconfig
	Patch rpi_arm64_defconfig.patch does not apply (enforce with -f)

[1]: https://layers.openembedded.org/layerindex/recipe/398253/
[2]: https://git.yoctoproject.org/meta-lts-mixins/commit/?h=scarthgap/u-boot&id=66ceeebd047d7fdfc8668b300319a76da8ae257d
[3]: https://git.yoctoproject.org/meta-lts-mixins/commit/?h=scarthgap/u-boot&id=16a823200c47413be169ba887e2786cb511cf17e
[4]: https://git.yoctoproject.org/meta-lts-mixins/commit/?h=scarthgap/u-boot&id=e9a44729f325a75bb11d45b106a06155aa1c3c36
[5]: https://git.yoctoproject.org/meta-lts-mixins/commit/?h=scarthgap/u-boot&id=68856926465b56b98599ab2506fceb0d1bcfad5b
[6]: https://source.denx.de/u-boot/u-boot/-/blob/v2025.01/configs/rpi_arm64_defconfig?ref_type=tags
[7]: https://source.denx.de/u-boot/u-boot/-/commit/d532df3a614cf834213f6740fd56f0fd4e2d3662#8461534a8d09221464e51be0654c79da54f178fa